### PR TITLE
allow for error handling

### DIFF
--- a/lib/simplebus.js
+++ b/lib/simplebus.js
@@ -133,6 +133,10 @@ function Client(port, host) {
             client = null;
         }
     }
+
+    this.on = function() {
+        client.on.apply(client, arguments);
+    }
     
     this.subscribe = function (predicate, callback) {
         var subid = ++ncallback;

--- a/test/client.js
+++ b/test/client.js
@@ -118,3 +118,14 @@ exports['Client Subscribe to Message using a Predicate'] = function(test) {
         bus.post({ operation: 'sale', price: 20, quantity: 1 });
     });
 }
+
+exports['Client Gracefully Errored when no Connection to Server'] = function(test) {
+    var times = 0;
+    var client = simplebus.createClient(3001);
+    client.start(function () {});
+    client.on("error", function() {
+        if (++times == 2) { //it is a bit unclear why it's called twice
+            test.done();
+        }
+    });
+}


### PR DESCRIPTION
We (me and sidrees) found your library helpful, but missing out on the error handling, which we desperately need. I asked sidres to propose a change, but he appears to have missed a spot. Here's a more generic approach with a test case. 

For the life of me, I did not find time to find out why on error callback is called twice.
