### PR TITLE
allow simply single i/o (pub/sub pattern)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://gumroad.com/l/hGYGh

--- a/lib/simplebus.js
+++ b/lib/simplebus.js
@@ -10,7 +10,7 @@ function Bus(size)
 	this.post = function(message) {
 		messages.push(message);
         
-        if (size && messages.length > size)
+        if (size != false && messages.length >= size)
             messages.shift();
         
 		subscriptions.forEach(function(sub) {


### PR DESCRIPTION
there were always 2 messages in the bus when size '1' was passed
